### PR TITLE
Nullify access token for the authentication request

### DIFF
--- a/lib/pipekit/client/connection.rb
+++ b/lib/pipekit/client/connection.rb
@@ -67,7 +67,7 @@ module Pipekit
       def authenticate!
         self.oauth_token = nil
 
-        response = self.class.post('https://oatuh.pipedrive.com/oauth/token', body: {
+        response = self.class.post('https://oauth.pipedrive.com/oauth/token', body: {
           grant_type: 'refresh_token',
           client_id: @client_id,
           client_secret: @client_secret,

--- a/lib/pipekit/client/connection.rb
+++ b/lib/pipekit/client/connection.rb
@@ -65,6 +65,8 @@ module Pipekit
       end
 
       def authenticate!
+        self.oauth_token = nil
+
         response = self.class.post('https://oatuh.pipedrive.com/oauth/token', body: {
           grant_type: 'refresh_token',
           client_id: @client_id,


### PR DESCRIPTION
If we pass the access token during the authenticate request, the server will return 401 as the token is invalid 

Fixed the typo in url according to https://pipedrive.readme.io/docs/marketplace-oauth-authorization
